### PR TITLE
Поправить пропорции блока create-tweet

### DIFF
--- a/common.blocks/create-tweet/create-tweet.styl
+++ b/common.blocks/create-tweet/create-tweet.styl
@@ -1,16 +1,18 @@
-.create-tweet{
+.create-tweet {
   display: none
   background: linear-gradient(to right, #944a71, #d95d92);
   border-radius: 50%;
   padding: 15px;
   box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.6);
+  width: 18px;
+  height: 18px;
 
-  &_visible{
+  &_visible {
     display: block;
   }
 
-  &__icon{
-    width: 18px;
-    height: 18px;
+  &__icon {
+    width: 100%;
+    height: 100%;
   }
 }


### PR DESCRIPTION
В браузере Chrome 52.0.2743.98 на Android 5 блок имеет вытянутую по вертикальной оси форму, не зависимо от того, что элементу внутри заданы точные размеры квадрата.
Исправил поведение. Элемент `icon` блока `create-tweet` всегда будет вписан в квадрат. Размер квадрата задаётся свойствами `width` и `height` у блока `create-tweet`.

PR исправляет переоткрытый issue https://github.com/shri-team5/pepo/issues/135#issuecomment-246208926
