### PR TITLE
Убрать ES6 специфичный синтаксис

### DIFF
--- a/common.blocks/app/app.js
+++ b/common.blocks/app/app.js
@@ -107,9 +107,9 @@ modules.define('app', ['i-bem__dom', 'jquery', 'tweet-toolbar'], function (provi
                         this.findBlockInside('feed').domElem,
                         tweets
                     );
-                    setTimeout(() => {
+                    setTimeout(function () {
                         this.findBlockInside('main').toggleMod('loading');
-                    }, 1000);
+                    }.bind(this), 1000);
                 }.bind(this))
                 .catch(function (err) {
                     console.log(err);

--- a/common.blocks/tweet-toolbar/tweet-toolbar.js
+++ b/common.blocks/tweet-toolbar/tweet-toolbar.js
@@ -5,9 +5,11 @@ provide(BEMDOM.decl(this.name,
         onSetMod: {
             js: {
                 inited: function () {
+                    var location = this.elem('location-link').html();
                     this.bindTo('reply', 'click', this._onReplyClick);
-                    let location = this.elem('location-link').html();
-                    if(location.length){this._loadAddress(location)}
+                    if (location.length) {
+                        this._loadAddress(location);
+                    }
                 }
             }
         },


### PR DESCRIPTION
В Safari (и, скорее всего, во всех браузерах, кроме последних версий Chrome) не срабатывала подгрузка ленты твитов из-за применения синтаксиса из нового стандарта.
