### PR TITLE
Изменить порт production сервера.

### DIFF
--- a/server/config/environments/production.js
+++ b/server/config/environments/production.js
@@ -1,6 +1,6 @@
 module.exports = {
     staticFolder: 'static',
-    defaultPort: 80,
+    defaultPort: 3000,
     cacheTTL: 100,
     sessionSecret: 'GHJKNBFGHJHKJGHHJJLKHJG',
 


### PR DESCRIPTION
С включением nginx на 80-м порту в режиме реверсивного прокси необходимо сменить порт production express.js-сервера. Теперь весь траффик шифруется (https).
