### PR TITLE
Починить высоту блока link-preview в Safari

### DIFF
--- a/common.blocks/link-preview/link-preview.styl
+++ b/common.blocks/link-preview/link-preview.styl
@@ -19,7 +19,6 @@
             max-width: 100%;
             min-width: 100%;
             max-height: 100%;
-            min-height: 100%;
             object-fit: contain;
         }
     }


### PR DESCRIPTION
В Safari на всех экземплярах блока `link-preview` устанавливается одинаковое значение высоты из-за того, что внутри стилей у `img` есть свойство `min-height: 100%;`. Пожертвуем же вертикальным выравниванием картинки по высоте для нормального отображения в Safari. Аминь.
